### PR TITLE
Added some missing bit number defines

### DIFF
--- a/hardware.inc
+++ b/hardware.inc
@@ -643,7 +643,6 @@ DEF rHDMA5 EQU $FF55
 
 DEF HDMA5F_MODE_GP  EQU %00000000 ; General Purpose DMA (W)
 DEF HDMA5F_MODE_HBL EQU %10000000 ; HBlank DMA (W)
-
 DEF HDMA5B_MODE EQU 7 ; DMA mode select (W)
 
 ; -- Once DMA has started, use HDMA5F_BUSY to check when the transfer is complete


### PR DESCRIPTION
Registers `OCPS`, `BCPS` and `LCDC` now have bit number defines. 
This is the first time I do anything like this, let me know if I'm doing anything wrong please.