### PR TITLE
Remove BOOTUP_B_CGB and BOOTUP_B_AGB

### DIFF
--- a/hardware.inc
+++ b/hardware.inc
@@ -1039,8 +1039,6 @@ def BOOTUP_A_MGB equ $FF
 
 ; Register B = CPU qualifier (if A is BOOTUP_A_CGB)
 def B_BOOTUP_B_AGB equ 0
-    def BOOTUP_B_CGB equ 0 << B_BOOTUP_B_AGB
-    def BOOTUP_B_AGB equ 1 << B_BOOTUP_B_AGB
 
 ; Register C = CPU qualifier
 def BOOTUP_C_DMG equ $13


### PR DESCRIPTION
According to [Pan Docs](https://gbdev.io/pandocs/Power_Up_Sequence.html#cgbdmg_b):

> If the [old licensee code](https://gbdev.io/pandocs/The_Cartridge_Header.html#014b--old-licensee-code) is $01, or the old licensee code is $33 and the [new licensee code](https://gbdev.io/pandocs/The_Cartridge_Header.html#01440145--new-licensee-code) is "01" ($30 $31), then B is the sum of all 16 [title](https://gbdev.io/pandocs/The_Cartridge_Header.html#0134-0143--title) bytes. Otherwise, B is $00. As indicated by the “+ 1” in the “AGB (DMG mode)” column, if on AGB, that value is increased by 1[2](https://gbdev.io/pandocs/Power_Up_Sequence.html#agbdmg_f).