### PR TITLE
Correct comments on RTC register bits to `r/w` not `wo`

### DIFF
--- a/hardware.inc
+++ b/hardware.inc
@@ -815,9 +815,9 @@ def RAMB_RTC_M  equ $09 ; minutes counter (0-59)
 def RAMB_RTC_H  equ $0A ; hours counter (0-23)
 def RAMB_RTC_DL equ $0B ; days counter, low byte (0-255)
 def RAMB_RTC_DH equ $0C ; days counter, high bit and other flags
-    def B_RAMB_RTC_DH_CARRY equ 7 ; 1 = days counter overflowed    [wo]
-    def B_RAMB_RTC_DH_HALT  equ 6 ; 0 = run timer, 1 = stop timer  [wo]
-    def B_RAMB_RTC_DH_HIGH  equ 0 ; days counter, high bit (bit 8) [wo]
+    def B_RAMB_RTC_DH_CARRY equ 7 ; 1 = days counter overflowed    [r/w]
+    def B_RAMB_RTC_DH_HALT  equ 6 ; 0 = run timer, 1 = stop timer  [r/w]
+    def B_RAMB_RTC_DH_HIGH  equ 0 ; days counter, high bit (bit 8) [r/w]
         def RAMB_RTC_DH_CARRY equ 1 << B_RAMB_RTC_DH_CARRY
         def RAMB_RTC_DH_HALT  equ 1 << B_RAMB_RTC_DH_HALT
         def RAMB_RTC_DH_HIGH  equ 1 << B_RAMB_RTC_DH_HIGH


### PR DESCRIPTION
Splits out the simple comment correction from #81.